### PR TITLE
従業員や企業と紐づけるスキルがちゃんと<label>されていなかった点の改修

### DIFF
--- a/src/main/resources/templates/co_lang.html
+++ b/src/main/resources/templates/co_lang.html
@@ -29,8 +29,8 @@
 				<td>
 					<div th:each = "skill : ${dataList}" th:object = "${skill}" class = "form-check form-check-inline h5">
 						<input type = "checkbox" name = "langId"
-						th:checked = "${langList.contains(skill.id)}" th:value = *{id} class = "form-check-input">
-						<label class = "form-check-label">[[*{name}]]</label>
+						th:checked = "${langList.contains(skill.id)}" th:value = *{id} th:id = *{name} class = "form-check-input">
+						<label class = "form-check-label" th:for =*{name}>[[*{name}]]</label>
 					</div>
 				</td>
 			</tr>

--- a/src/main/resources/templates/emp_lang.html
+++ b/src/main/resources/templates/emp_lang.html
@@ -29,8 +29,8 @@
 				<td>
 					<div th:each = "skill : ${dataList}" class = "form-check form-check-inline h5">
 						<input type = "checkbox" name = "langId" class = "form-check-input"
-							th:checked = "${langList.contains(skill.id)}" th:value = ${skill.id}>
-							<label class = "form-check-label">[[${skill.name}]]</label>
+							th:checked = "${langList.contains(skill.id)}" th:id = ${skill.name} th:value = ${skill.id}>
+							<label class = "form-check-label" th:for = ${skill.name}>[[${skill.name}]]</label>
 					</div>
 				</td>
 			</tr>


### PR DESCRIPTION
従業員と企業に紐づけるスキルの選択画面で、チェックボックスと<label>が正常に紐づけされていなかったので、改修した。